### PR TITLE
Strip Path to Basename

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -161,7 +161,7 @@ object Main {
   /** Read a file by ID */
   private def do_readfile(state: State, cmd: ReadFile): CLIError \/ Unit = {
     state.client.readRecord(cmd.record_id).asScala.map({ rec =>
-      val filename = cmd.dest.getOrElse(rec.data("filename"))
+      val filename = cmd.dest.getOrElse(Paths.get(rec.data("filename")).getFileName.toString)
       val stream = new FileOutputStream(filename)
       try {
         stream.write(Base64.decode(rec.data("contents")))
@@ -239,7 +239,9 @@ object Main {
 
   /** Write a file */
   private def do_writefile(state: State, cmd: WriteFile): CLIError \/ Unit = {
-    val data = Files.readAllBytes(Paths.get(cmd.filename))
+    val path = Paths.get(cmd.filename)
+    val filename = path.getFileName.toString
+    val data = Files.readAllBytes(path)
     val meta = new Meta(state.config.client_id,
       cmd.user_id.getOrElse(state.config.client_id),
       cmd.ctype)
@@ -247,8 +249,8 @@ object Main {
     val fileTypeMap = new MimetypesFileTypeMap()
 
     val dataMap = Map(
-      "filename" -> cmd.filename,
-      "content-type" -> fileTypeMap.getContentType(cmd.filename),
+      "filename" -> filename,
+      "content-type" -> fileTypeMap.getContentType(filename),
       "contents" -> Base64.encode(data)
     )
 


### PR DESCRIPTION
To avoid writing the absolute path of a file to the PDS, strip things down to the base filename when we write. Also, to ensure we don't accidentally have a full path stored in the system that can overwrite a file unintentionally (i.e. someone used `write` manually rather than `writefile`), strip the stored filename to its base as well.

If an end user does wish to use an absolute (or relative) path when reading a file back out, they can still specify the path using the `--dest` flag.