### PR TITLE
Rename to E3DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,36 @@
 # Tozny Personal Data Service
 
-The Tozny Personal Data Service (PDS) is an end-to-end encrypted
-storage platform with powerful sharing and consent management
-features.
+The Tozny End-to-End Encrypted Database (E3DB) is a storage
+platform with powerful sharing and consent management features.
 
-Tozny's PDS provides a familiar JSON-based NoSQL-style API for reading,
+Tozny's E3DB provides a familiar JSON-based NoSQL-style API for reading,
 writing, and listing JSON data stored securely in the cloud.
 
 ## Installation
 
-The Tozny PDS software contains the following components:
+The Tozny E3DB software contains the following components:
 
 - A Command Line Interface (CLI) tool used for registering
   accounts and performing interactive database operations.
 
-- A Java SDK for connecting to the PDS and performing
+- A Java SDK for connecting to E3DB and performing
   database operations from Java applications or web services.
 
-To install the PDS CLI, download the software from:
+To install the E3DB CLI, download the software from:
 
-    https://github.com/tozny/pds/releases/download/0.4.1/pds-cli-0.4.1.zip
+    https://github.com/tozny/e3db/releases/download/0.5.0/e3db-cli-0.5.0.zip
 
-Unzip the `pds-cli-0.4.1.zip` file in a convenient location and add
-the `pds-cli-0.4.1.zip/bin` directory to your `PATH`.
+Unzip the `e3db-cli-0.5.0.zip` file in a convenient location and add
+the `e3db-cli-0.5.0/bin` directory to your `PATH`.
 
 ## Registration
 
-Before you can use the PDS from your Java application, you must
+Before you can use E3DB from your Java application, you must
 register an account and receive API credentials. To register using
-the Tozny PDS CLI, run:
+the Tozny E3DB CLI, run:
 
 ```
-$ pds register
+$ e3db register
 ```
 
 This will prompt interactively for your e-mail address (and the
@@ -39,7 +38,7 @@ server URL---accept the default by pressing return):
 
 ```
 E-Mail Address []: foo@example.com<RETURN>
-Service URL [https://api.staging.pds.tozny.com/v1]: <RETURN>
+Service URL [https://api.e3db.tozny.com/v1]: <RETURN>
 ```
 
 Tozny will send a confirmation e-mail to the address entered
@@ -47,29 +46,29 @@ during the registration process. Simply click the link in the
 e-mail to complete the registration.
 
 After a successful registration, API credentials and other
-configuration will be written to the file `$HOME/.tozny/pds.json`.
+configuration will be written to the file `$HOME/.tozny/e3db.json`.
 
 ## CLI Examples
 
-These examples demonstrate how to use the PDS Command Line
-Interface to interactively use the PDS as a database without
+These examples demonstrate how to use the E3DB Command Line
+Interface to interactively use E3DB as a database without
 the need to write any code.
 
 ### Writing Records
 
 To write a record containing free-form JSON data, use the
-`pds write` subcommand. Each record is tagged with a "content
+`e3db write` subcommand. Each record is tagged with a "content
 type", which is a string that you choose used to identify the
 structure of your data.
 
-In this example, we write an address book entry into our PDS:
+In this example, we write an address book entry into E3DB:
 
 ```
-$ pds write address_book '{"name": "John Doe", "phone": "503-555-1212"}'
+$ e3db write address_book '{"name": "John Doe", "phone": "503-555-1212"}'
 874b41ff-ac84-4961-a91d-9e0c114d0e92
 ```
 
-Once the PDS has written the record, it outputs the Universally Unique
+Once E3SB has written the record, it outputs the Universally Unique
 Identifier (UUID) of the newly created data. This can be used later
 to retrieve the specific record.
 
@@ -77,22 +76,22 @@ You can also write a file containing JSON data using the following
 command syntax:
 
 ```
-$ pds write address_book @contact1.json
+$ e3db write address_book @contact1.json
 ```
 
 ### Listing Records
 
-To list all records that we have access to in our PDS, use the
-`pds ls` command:
+To list all records that we have access to in E3DB, use the
+`e3db ls` command:
 
 ```
-$ ./pds ls
+$ ./e3db ls
 Record ID                                 Producer      Type
 ------------------------------------------------------------------------------
 874b41ff-ac84-4961-a91d-9e0c114d0e92      e04af806...   address_book
 ```
 
-For each record accessible in our PDS, the `ls` command lists the record ID,
+For each record accessible in E3DB, the `ls` command lists the record ID,
 ID of the client that wrote the record, and the type of data contained
 in the record.
 
@@ -106,7 +105,7 @@ printed by the CLI when the record was first written, and also displayed
 in the output of the `ls` command.
 
 ```
-$ pds read 874b41ff-ac84-4961-a91d-9e0c114d0e92
+$ e3db read 874b41ff-ac84-4961-a91d-9e0c114d0e92
 
 Record ID:           874b41ff-ac84-4961-a91d-9e0c114d0e92
 Record Type:         address_book
@@ -124,15 +123,15 @@ such as its unique ID, type, and the IDs of the client that wrote
 the record and its associated user. Then it displays each field
 from the original JSON data, along with its decrypted value.
 
-The Tozny PDS stores each field encrypted using 256-bit AES
+The Tozny E3DB stores each field encrypted using 256-bit AES
 encryption with a unique key for each client, user, and
-data type. Normally, the PDS client performs this encryption
+data type. Normally, the E3DB client performs this encryption
 and decryption transparently. To skip this decryption step and
 retrieve the raw encrypted record data, add the `--raw` option
-to `pds read`:
+to `e3db read`:
 
 ```
-$ pds read --raw 874b41ff-ac84-4961-a91d-9e0c114d0e92
+$ e3db read --raw 874b41ff-ac84-4961-a91d-9e0c114d0e92
 
 Record ID:           874b41ff-ac84-4961-a91d-9e0c114d0e92
 Record Type:         address_book
@@ -147,19 +146,19 @@ phone                eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..LKSzjq5l3iDOVy-M.8
 
 ### Sharing Records
 
-The Tozny PDS allows you to share your data with another PDS
+The Tozny E3DB allows you to share your data with another E3DB
 client. Sharing records allows your records to show in the
 record list for another client. In order to set up sharing,
 you must know the unique ID of the client you wish to share
-with. If the other client is using the PDS CLI, you can
-retrieve this by running `pds info`.
+with. If the other client is using the E3DB CLI, you can
+retrieve this by running `e3db info`.
 
-The current version of the PDS client allows you to share
+The current version of the E3DB client allows you to share
 records based on their content type. For example, to share
 all address book entries with another client:
 
 ```
-$ pds share eb540605-9f2f-4251-bd40-90ba8da99615 address_book
+$ e3eb share eb540605-9f2f-4251-bd40-90ba8da99615 address_book
 ```
 
 This command will set up access control policy to allow the
@@ -170,9 +169,9 @@ client so they can decrypt the contents of each field.
 
 ## Code Examples
 
-### Importing the PDS Client Library
+### Importing the E3DB Client Library
 
-### Creating a PDS Client
+### Creating a E3DB Client
 
 ### Writing Records
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tozny Personal Data Service
+# Tozny End-to-End Encrypted Database
 
 The Tozny End-to-End Encrypted Database (E3DB) is a storage
 platform with powerful sharing and consent management features.

--- a/build.sbt
+++ b/build.sbt
@@ -40,5 +40,5 @@ libraryDependencies ++= Seq(
   "org.bitbucket.b_c" % "jose4j" % "0.5.2",
 
   // Tozny Libraries
-  "com.tozny.pds" % "pds-client" % "0.4.1"
+  "com.tozny.e3db" % "e3db-client" % "0.4.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ executableScriptName := "e3db"
 
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.jcenterRepo
+resolvers += "tozny" at "https://maven.tozny.com/repo"
 
 libraryDependencies ++= Seq(
   // Core Libraries
@@ -40,5 +41,5 @@ libraryDependencies ++= Seq(
   "org.bitbucket.b_c" % "jose4j" % "0.5.2",
 
   // Tozny Libraries
-  "com.tozny.e3db" % "e3db-client" % "0.4.1"
+  "com.tozny.e3db" % "e3db-client" % "0.5.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@
 // All Rights Reserved.
 //
 
-organization := "com.tozny.pds"
-version := "0.4.1"
+organization := "com.tozny.e3db"
+version := "0.5.0"
 
 scalaVersion := "2.11.8"
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
@@ -17,7 +17,7 @@ enablePlugins(DockerPlugin)
 enablePlugins(AshScriptPlugin)
 
 dockerBaseImage := "tozny/java"
-executableScriptName := "pds"
+executableScriptName := "e3db"
 
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.jcenterRepo

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,10 +13,10 @@ object CliBuild extends Build {
 
   /**
     * Set up an external dependency on the SDK project if the
-    * PDS-CLIENT-SDK environment variable or system property is defined.
+    * E3DB-CLIENT-SDK environment variable or system property is defined.
     */
-  val sdkProject: Seq[ClasspathDependency] = Option(System.getenv("PDS-CLIENT-SDK"))
-    .orElse(Option(System.getProperty("PDS-CLIENT-SDK")))
+  val sdkProject: Seq[ClasspathDependency] = Option(System.getenv("E3DB-CLIENT-SDK"))
+    .orElse(Option(System.getProperty("E3DB-CLIENT-SDK")))
     .map(Paths.get(_).toFile)
     .filter(_.isDirectory)
     .map(proj => {
@@ -24,7 +24,7 @@ object CliBuild extends Build {
       RootProject(base = proj)
     }).toSeq
 
-  lazy val root: Project = Project(id = "pds-cli",
+  lazy val root: Project = Project(id = "e3db-cli",
     base = file(".")
   ).dependsOn(sdkProject :_*)
 }

--- a/src/main/scala/config.scala
+++ b/src/main/scala/config.scala
@@ -5,7 +5,7 @@
 // All Rights Reserved.
 //
 
-package com.tozny.pds.cli
+package com.tozny.e3db.cli
 
 import scala.io.StdIn
 import scala.collection.JavaConversions._
@@ -21,7 +21,7 @@ import argonaut._
 import Argonaut._
 import org.jose4j.jwk._
 
-/** Configuration file for the PDS CLI. */
+/** Configuration file for the E3DB CLI. */
 case class Config (
   client_id: UUID,
   api_url: String,

--- a/src/main/scala/error.scala
+++ b/src/main/scala/error.scala
@@ -10,7 +10,7 @@ package com.tozny.e3db.cli
 import scalaz._
 import scalaz.syntax.either._
 
-import com.tozny.pds.client.PDSClientError
+import com.tozny.e3db.client.E3DBClientError
 
 sealed trait CLIError {
   val message: String
@@ -29,7 +29,7 @@ case class MiscError(message: String, exception: Throwable) extends CLIError
 object CLIError {
   def handle[A](f: => A): \/[CLIError, A] =
     \/.fromTryCatchNonFatal(f).leftMap {
-      case e: PDSClientError => ClientError(e.getMessage, e)
+      case e: E3DBClientError => ClientError(e.getMessage, e)
       case e => MiscError(e.getMessage, e)
     }
 }

--- a/src/main/scala/error.scala
+++ b/src/main/scala/error.scala
@@ -5,7 +5,7 @@
 // All Rights Reserved.
 //
 
-package com.tozny.pds.cli
+package com.tozny.e3db.cli
 
 import scalaz._
 import scalaz.syntax.either._

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -22,7 +22,7 @@ import argonaut.JsonParser
 import org.jose4j.jwk._
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers
 
-import com.tozny.pds.client._
+import com.tozny.e3db.client._
 import org.jose4j.base64url.Base64
 import org.jose4j.jwe._
 
@@ -322,7 +322,7 @@ object Main {
           .setClientId(config.client_id)
           .setConfigDir(new ConfigDir(opts.config_file.getParent.toFile))
           .build()
-        client = new HttpPDSClientBuilder()
+        client = new HttpE3DBClientBuilder()
           .setClientId(config.client_id)
           .setServiceUri(config.api_url)
           .setApiKeyId(config.api_key_id)
@@ -339,7 +339,7 @@ object Main {
     (try {
       runWithOpts(OptionParser.parse(args))
     } catch {
-      case e: PDSClientError => ClientError(e.getMessage, e).left
+      case e: E3DBClientError => ClientError(e.getMessage, e).left
       case e: Exception      => MiscError(e.getMessage, e).left
     }).leftMap {
       case err: ConfigError => {

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -1,11 +1,11 @@
 //
-// main.scala --- PDS CLI main program.
+// main.scala --- E3DB CLI main program.
 //
 // Copyright (C) 2016, Tozny, LLC.
 // All Rights Reserved.
 //
 
-package com.tozny.pds.cli
+package com.tozny.e3db.cli
 
 import java.io.FileOutputStream
 import java.nio.file.{Files, Paths}
@@ -60,7 +60,7 @@ object Main {
     }
   }
 
-  private val DEFAULT_SERVICE_URL = "https://api.staging.pds.tozny.com/v1"
+  private val DEFAULT_SERVICE_URL = "https://api.e3db.tozny.com/v1"
   private val KEY_PAIR_BITS = 4096
   private val CAB_VERSION = "1.0"
 
@@ -68,7 +68,7 @@ object Main {
   private def do_register(opts: Options): CLIError \/ Unit = {
     val email = readLineRequired("E-Mail Address", "")
     val url = readLineDefault("Service URL", DEFAULT_SERVICE_URL)
-    val mgr = ConfigFileKeyManager.create(opts.config_file.getParent.resolve("pds_key.json").toFile)
+    val mgr = ConfigFileKeyManager.create(opts.config_file.getParent.resolve("e3db_key.json").toFile)
     val resp = new Registration.Builder()
       .setServiceUri(url)
       .setEmail(email)
@@ -259,7 +259,7 @@ object Main {
     ok
   }
 
-  /** Read a CAB from the PDS and print it. */
+  /** Read a CAB from E3DB and print it. */
   private def do_getcab(state: State, cmd: GetCab): CLIError \/ Unit = {
     state.client.getCab(cmd.writer_id, cmd.user_id, cmd.record_type).asScala.map({ cab =>
 
@@ -282,7 +282,7 @@ object Main {
     ok
   }
 
-  /** Read a client's public key from the PDS and print it. */
+  /** Read a client's public key from E3DB and print it. */
   private def do_getkey(state: State, cmd: GetKey): CLIError \/ Unit = {
     state.client.getClientKey(cmd.client_id).asScala.map(_.toJson).map({ keyJson =>
       \/.fromEither(JsonParser.parse(keyJson)).map { obj =>
@@ -316,7 +316,7 @@ object Main {
     } else {
       for {
         config <- Config.load(opts.config_file)
-        keyManager = ConfigFileKeyManager.get(opts.config_file.getParent.resolve("pds_key.json").toFile)
+        keyManager = ConfigFileKeyManager.get(opts.config_file.getParent.resolve("e3db_key.json").toFile)
         cabManager = new ConfigCabManagerBuilder()
           .setKeyManager(keyManager)
           .setClientId(config.client_id)
@@ -344,7 +344,7 @@ object Main {
     }).leftMap {
       case err: ConfigError => {
         println(err.message)
-        println("Run `pds register' to create an account.")
+        println("Run `e3db register' to create an account.")
       }
 
       case err: MiscError => {

--- a/src/main/scala/options.scala
+++ b/src/main/scala/options.scala
@@ -5,7 +5,7 @@
 // All Rights Reserved.
 //
 
-package com.tozny.pds.cli
+package com.tozny.e3db.cli
 
 import java.nio.file.{InvalidPathException,Path,Paths}
 import java.util.UUID
@@ -17,7 +17,7 @@ import scalaz.syntax.apply._
 import net.bmjames.opts._
 
 /**
- * Command-line options to the PDS utility.
+ * Command-line options to the E3DB utility.
  *
  * This class contains global options that are applicable to all
  * commands. Each command contains options that are local to itself.
@@ -38,7 +38,7 @@ case class Ls(limit: Int, offset: Int) extends Command
 case object Register extends Command
 case object Info extends Command
 
-// TODO: These should arguably be subcommands like "pds cab get"...
+// TODO: These should arguably be subcommands like "e3db cab get"...
 case class GetCab(writer_id: UUID, user_id: UUID, record_type: String) extends Command
 case class GetKey(client_id: UUID) extends Command
 
@@ -88,7 +88,7 @@ object OptionParser {
   private val writeFileOpts: Parser[Command] =
     (optional(option[UUID](parseUUID, long("user"), help("Owning user of record"))) |@|
       strArgument(metavar("TYPE"), help("Record type")) |@|
-      strArgument(metavar("FILENAME"), help("Path to file to write to PDS")))(WriteFile)
+      strArgument(metavar("FILENAME"), help("Path to file to write to E3DB")))(WriteFile)
 
   // Options for the `ls` command:
   private val lsOpts: Parser[Command] =
@@ -118,9 +118,9 @@ object OptionParser {
   private val revokeOpts: Parser[Command] =
     (argument(parseUUID, metavar("READER_ID"), help("ID of reader."))).map(RevokeSharing.apply)
 
-  // Default location of the PDS CLI config file.
+  // Default location of the E3DB CLI config file.
   private val defaultConfigFile =
-    Paths.get(System.getProperty("user.home"), ".tozny", "pds.json")
+    Paths.get(System.getProperty("user.home"), ".tozny", "e3db.json")
 
   private val parseOpts: Parser[Options] =
     // Global options:
@@ -133,13 +133,13 @@ object OptionParser {
      // Subcommands:
      subparser[Command](
        command("info",      info(pure(Info),               progDesc("Display configuration info"))),
-       command("read",      info(readOpts <*> helper,      progDesc("Read data from the PDS"))),
-       command("readfile",  info(readFileOpts <*> helper,  progDesc("Read a file from the PDS"))),
-       command("write",     info(writeOpts <*> helper,     progDesc("Write data to the PDS"))),
-       command("writefile", info(writeFileOpts <*> helper, progDesc("Write a file to the PDS"))),
-       command("ls",        info(lsOpts <*> helper,        progDesc("List my records in the PDS"))),
-       command("register",  info(pure(Register),           progDesc("Register an account with the PDS"))),
-       command("getcab",    info(getCabOpts <*> helper,    progDesc("Retrieve a CAB from the PDS"))),
+       command("read",      info(readOpts <*> helper,      progDesc("Read data from E3DB"))),
+       command("readfile",  info(readFileOpts <*> helper,  progDesc("Read a file from E3DB"))),
+       command("write",     info(writeOpts <*> helper,     progDesc("Write data to E3DB"))),
+       command("writefile", info(writeFileOpts <*> helper, progDesc("Write a file to E3DB"))),
+       command("ls",        info(lsOpts <*> helper,        progDesc("List my records in E3DB"))),
+       command("register",  info(pure(Register),           progDesc("Register an account with E3DB"))),
+       command("getcab",    info(getCabOpts <*> helper,    progDesc("Retrieve a CAB from E3DB"))),
        command("getkey",    info(getKeyOpts <*> helper,    progDesc("Retrieve a client's public key"))),
        command("share",     info(shareOpts <*> helper,     progDesc("Start sharing records with the given user.")))/*,
        not yet working
@@ -157,5 +157,5 @@ object OptionParser {
    * if an error occurs.
    */
   def parse(args: Array[String]): Options =
-    customExecParser(args.toList, "pds", optPrefs, opts)
+    customExecParser(args.toList, "e3db", optPrefs, opts)
 }


### PR DESCRIPTION
In addition to changes in code/docs, the repository will need to be renamed as well to `e3db`.