### PR TITLE
Fix script errors on Ubuntu

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings")
 
 enablePlugins(JavaAppPackaging)
 enablePlugins(DockerPlugin)
-enablePlugins(AshScriptPlugin)
 
 dockerBaseImage := "tozny/java"
 executableScriptName := "e3db"


### PR DESCRIPTION
- Remove `AshScriptPlugin` from SBT build.
- This leads to the 'e3db' script clearly depending on Bash,
  instead of one that works with 'ash' but not 'dash'.