### PR TITLE
Feature/sharing audit

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -221,6 +221,22 @@ object Main {
     ok
   }
 
+  private def do_audit(state: State, cmd: ListReaders): CLIError \/ Unit = {
+    val user_id = cmd.user_id.getOrElse(state.config.client_id)
+    val readers = state.client.listReaders(user_id, cmd.ctype)
+
+    println(s"Records of type `${cmd.ctype}` are shared with these client IDs:")
+
+    readers.foreach { reader =>
+      if (reader == state.config.client_id)
+        println(s"* ${reader.toString} (me)")
+      else
+        println(s"* ${reader.toString}")
+    }
+
+    ok
+  }
+
   private def do_revoke(state: State, cmd: RevokeSharing): CLIError \/ Unit = {
     val user_id = state.config.client_id // assume writer == user for now
     state.client.revokeSharing(user_id, user_id, cmd.reader)
@@ -354,6 +370,7 @@ object Main {
       case cmd : WriteFile => do_writefile(state, cmd)
       case cmd : Delete => do_delete(state, cmd)
       case cmd : Sharing => do_share(state, cmd)
+      case cmd : ListReaders => do_audit(state, cmd)
       case cmd : RevokeSharing => do_revoke(state, cmd)
       case cmd : GetCab => do_getcab(state, cmd)
       case cmd : GetKey => do_getkey(state, cmd)

--- a/src/main/scala/options.scala
+++ b/src/main/scala/options.scala
@@ -53,6 +53,7 @@ sealed trait Sharing
 case class AddSharing(ctype: String, reader: UUID) extends Command with Sharing
 case class RemoveSharing(ctype: String, reader: UUID) extends Command with Sharing
 case class RevokeSharing(reader: UUID) extends Command
+case class ListReaders(user_id: Option[UUID], ctype: String) extends Command
 
 object OptionParser {
   /** Argument parser for UUID parameters. */
@@ -135,6 +136,10 @@ object OptionParser {
   private val revokeOpts: Parser[Command] =
     (argument(parseUUID, metavar("READER_ID"), help("ID of reader."))).map(RevokeSharing.apply)
 
+  private val listReaderOpts: Parser[Command] =
+    (optional(option[UUID](parseUUID, long("user"), help("Owning user of records"))) |@|
+      strArgument(metavar("TYPE"), help("Record type")))(ListReaders)
+
   // Default location of the E3DB CLI config file.
   private val defaultConfigDir = Paths.get(System.getProperty("user.home"), ".tozny")
 
@@ -164,7 +169,8 @@ object OptionParser {
        command("getcab",    info(getCabOpts <*> helper,    progDesc("Retrieve a CAB from E3DB."))),
        command("getkey",    info(getKeyOpts <*> helper,    progDesc("Retrieve a client's public key."))),
        command("feedback",  info(pure(Feedback),           progDesc("Provide E3DB feedback to Tozny."))),
-       command("share",     info(shareOpts <*> helper,     progDesc("Start sharing records with the given reader.")))/*,
+       command("share",     info(shareOpts <*> helper,     progDesc("Start sharing records with the given reader."))),
+       command("audit",     info(listReaderOpts <*> helper, progDesc("Audit the readers allowed to view a given type.")))/*,
        not yet working
        command("deny",     info(denyOpts <*> helper,  progDesc("Stop sharing records with the given user.")))*/,
        command("revoke",    info(revokeOpts <*> helper,      progDesc("Revoke all sharing with the given reader.")))


### PR DESCRIPTION
Add support for enumerating the client IDs with whom a particular record type is shared.

Dependent on tozny/e3db-client/pull/17